### PR TITLE
only accept named --input arg (instead of positional)

### DIFF
--- a/tailbuild.js
+++ b/tailbuild.js
@@ -28,7 +28,7 @@ let args = arg({
 });
 
 let output = args['_'][0] || args['--output']
-let input = args['_'][1] || args['--input']
+let input = args['--input']
 let referenceFiles = args['--files']
 let shouldWatch = args['--watch']
 let shouldMinify = args['--minify']


### PR DESCRIPTION
Hi Caleb,

There is an issue where `input` arg has to come second (after output) otherwise it will throw an unknown argument error.

This fixes that by only accepting explicit `--input` arg